### PR TITLE
Feature split artist search id by 20

### DIFF
--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,13 @@
+/**
+ * 배열 stringBulkList의 인수를 splitCount만큼 재귀적으로 나눠줍니다.
+ */
+export const chunks: (
+  splitCount: number,
+) => (stringBulkList: string[]) => string[][] =
+  (splitCount: number) => (stringBulkList: string[]) =>
+    stringBulkList.length <= 2 * splitCount
+      ? [[...stringBulkList]]
+      : [
+          stringBulkList.slice(0, splitCount),
+          ...chunks(splitCount)(stringBulkList.slice(splitCount)),
+        ];


### PR DESCRIPTION
@appear


멀티 아티스트 id로 프로필을 가져올 경우 
<img width="398" alt="image" src="https://github.com/f-lab-edu/vinlyify/assets/102423086/f20a326f-bd46-453a-81ca-d7a1e0114969">

id개수가 너무 많으면 다음과 같이 400 에러가 발생합니다 😢
<img width="1144" alt="image" src="https://github.com/f-lab-edu/vinlyify/assets/102423086/e6c9630e-a2f1-4c30-a20d-b920073d23f4">
<img width="688" alt="image" src="https://github.com/f-lab-edu/vinlyify/assets/102423086/313235dd-5442-4770-8bd0-093ce740c1dc">

따라서 20개씩 id 배열을 잘라줘서 요청을 보내는 방식으로 변경했습니다.
