### PR TITLE
Remove page param on tab change

### DIFF
--- a/src/components/Search/SearchResult/TabSelection/index.tsx
+++ b/src/components/Search/SearchResult/TabSelection/index.tsx
@@ -1,3 +1,4 @@
+import { URL_PARAMS } from '@/constants/url';
 import classNames from 'classnames/bind';
 import { useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -21,6 +22,7 @@ export default function TabSelection() {
 
   const handleSelectMenu = useCallback(
     (item: keyof typeof TAB) => {
+      searchParams.delete(URL_PARAMS.PAGE);
       const searchParamKeyValuePair = [...searchParams].reduce(
         (acc, curr) => {
           const [key, val] = curr;

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -1,0 +1,18 @@
+export const API = {
+  LOGIN: 'https://vinylify-express.vercel.app/',
+  SPOTIFY: 'https://api.spotify.com/v1/',
+};
+export const PAGE = {
+  MAIN: '/',
+  ERROR: '/error',
+  MYPAGE: '/mypage',
+  SEARCH: '/search',
+  MUSIC_INFO: '/music-info',
+  LOGGED_IN: '/me',
+};
+
+export const URL_PARAMS = {
+  KEYWORD: 'keyword',
+  SCOPE: 'scope',
+  PAGE: 'page',
+};


### PR DESCRIPTION
@appear 
새로고침 등을 해도 페이지에 해당 데이터를 유지하기 위해 
페이지 변경 시 url param으로 `?page=${번호}`를 추가해줍니다.

탭 변경 시 페이징 urlparam을 제거해줘서 초기화합니다.